### PR TITLE
Bump pinned dash version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dwave-ocean-sdk>=5.5.0
-dash==2.6.0
+dash==2.7.0
 dash-bootstrap-components==1.2.1
 pandas==1.3.5
 


### PR DESCRIPTION
Bump version to avoid a deprecated `flask` call, see [here](https://github.com/plotly/dash/releases/tag/v2.7.0) for details.