### PR TITLE
Add devcontainer.json / prepare for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Ocean Development Environment",
+
+	// python 3.11 on debian, with latest Ocean and optional packages
+	// source repo: https://github.com/dwavesystems/ocean-dev-docker
+	"image": "docker.io/dwavesys/ocean-dev:latest",
+
+	// install repo requirements on create and content update
+	"updateContentCommand": "pip install -r requirements.txt",
+
+	// forward/expose container services (relevant only when run locally)
+	"forwardPorts": [
+		// dwave-inspector web app
+		18000, 18001, 18002, 18003, 18004,
+		// OAuth connect redirect URIs
+		36000, 36001, 36002, 36003, 36004
+	],
+
+	"portsAttributes": {
+		"18000-18004": {
+			"label": "D-Wave Problem Inspector",
+			"requireLocalPort": true
+		},
+		"36000-36004": {
+			"label": "OAuth 2.0 authorization code redirect URI",
+			"requireLocalPort": true
+		}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"workbench": {
+					"editorAssociations": {
+						"*.md": "vscode.markdown.preview.editor"
+					},
+					"startupEditor": "readme"
+				}
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter"
+			]
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Open in Leap IDE](
-  https://cdn-assets.cloud.dwavesys.com/shared/latest/badges/leapide.svg)](
-  https://ide.dwavesys.io/#https://github.com/dwave-examples/tour-planning)
+[![Open in GitHub Codespaces](
+  https://img.shields.io/badge/Open%20in%20GitHub%20Codespaces-333?logo=github)](
+  https://codespaces.new/dwave-examples/tour-planning?quickstart=1)
 
 # Tour Planning
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 dwave-ocean-sdk>=5.5.0
 dash==2.7.0
 dash-bootstrap-components==1.2.1
-pandas==1.3.5
+pandas>=1.3.5
 
 # Needed only for unit testing
-parameterized==0.8.1
-pytest==7.1.3
-pytest-mock==3.10.0
+parameterized
+pytest
+pytest-mock


### PR DESCRIPTION
- Add https://github.com/dwavesystems/ocean-devcontainer/commit/f99ab027fa7ec58a5ef5bd8bd4fb646c14dd32fc (v1.1.0)
- Update the readme "Open in" badge to use Codespaces
- Relax pip requirements for py311