### PR TITLE
Fix failed Unix unittest 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dwave-ocean-sdk>=6.6.0
-dash==2.7.0
+dwave-ocean-sdk>=7.0.0
+dash==2.14.1
 dash-bootstrap-components==1.2.1
 pandas>=1.3.5
 


### PR DESCRIPTION
Unittests fail on all three OSs, this fixes for Unix, and I'll see if it helps for MacOS and Win. The Win unitests fail on a colorama unitttest problem: I don't have Python 3.12 on Win to test that and am wondering whether preventing the unittesting of colorama would be a workaround. We'll see, let's start with Unix.