### PR TITLE
Fix failed Win unittest on colorama

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore-glob="*colorama*"
+testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore-glob="*colorama*"


### PR DESCRIPTION
This [PR](https://github.com/dwave-examples/tour-planning/pull/56) fixed the failed unit tests for Unix. Windows unitesting is failing because it runs uinttesting on colorama. I don't think those failed unittests are relevant to the application and when I create what seems like an identical environment locally, those unittests pass (both also with colorama version 0.4.6 not shown below). 

 CircleCI Win:
```
platform win32 -- Python 3.10.11, pytest-8.2.2, pluggy-1.5.0
rootdir: C:\Users\circleci\project
plugins: dash-2.14.1, mock-3.14.0
collected 241 items

python\tools\Lib\site-packages\pip\_vendor\colorama\tests\ansi_test.py . [  0%]
..                                                                       [  1%]
python\tools\Lib\site-packages\pip\_vendor\colorama\tests\ansitowin32_test.py . [  1%]
.................FF...                                                   [ 10%]
python\tools\Lib\site-packages\pip\_vendor\colorama\tests\initialise_test.py s [ 11%]
sssssssssF                                                               [ 15%]
python\tools\Lib\site-packages\pip\_vendor\colorama\tests\isatty_test.py . [ 15%]
......                                                                   [ 18%]
python\tools\Lib\site-packages\pip\_vendor\colorama\tests\winterm_test.py . [ 18%]
..FFFF.                
```

Local Win:
```
platform win32 -- Python 3.10.11, pytest-8.2.2, pluggy-1.5.0
rootdir: C:\Users\jpasvolsky\pyenv\examples\tour_planning_3_10_11
plugins: dash-2.14.1, mock-3.14.0
collected 52 items

..\Lib\site-packages\colorama\tests\ansi_test.py ...                                                 [  5%]
..\Lib\site-packages\colorama\tests\ansitowin32_test.py .......................                      [ 50%]
..\Lib\site-packages\colorama\tests\initialise_test.py ssssssssss.                                   [ 71%]
..\Lib\site-packages\colorama\tests\isatty_test.py .......                                           [ 84%]
..\Lib\site-packages\colorama\tests\winterm_test.py ........                                         [100%]

===================================== 42 passed,
```

So until the failed colorama unitest is fixed, this PR should skip that test. If anyone has a better fix, let me know,